### PR TITLE
Fix list page template for modern Hugo versions

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,7 @@
      {{ range .Pages }}
           <div style="border: 1px solid black; margin:10px; padding:10px; ">
                <div style="font-size:20px;">
-                    <a href="{{.URL}}">{{.Title}}</a>
+                    <a href="{{.Permalink}}">{{.Title}}</a>
                </div>
                <div style="color:grey; font-size:16px;">{{ dateFormat "Monday, Jan 2, 2006" .Date }}</div>
                <div style="color:grey; font-size:16px;">{{ if .Params.tags }}<strong>Tags:</strong> {{range .Params.tags}}<a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a> {{end}}{{end}}</div>


### PR DESCRIPTION
Replaces `{{.URL}}` with `{{.Permalink}}` for compatibility with latest Hugo version.