### PR TITLE
Update to .Permalink for newer Hugo versions

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,7 @@
      {{ range .Pages }}
           <div style="border: 1px solid black; margin:10px; padding:10px; ">
                <div style="font-size:20px;">
-                    <a href="{{.URL}}">{{.Title}}</a>
+                    <a href="{{.Permalink}}">{{.Title}}</a>
                </div>
                <div style="color:grey; font-size:16px;">{{ dateFormat "Monday, Jan 2, 2006" .Date }}</div>
                <div style="color:grey; font-size:16px;">{{ if .Params.tags }}<strong>Tags:</strong> {{range .Params.tags}}<a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a> {{end}}{{end}}</div>


### PR DESCRIPTION
The .URL is depricated, and causes the youtube tutorial to fail when running 'hugo serve -D'. I have changed .URL to .Permalink and now it works!