### PR TITLE
Update list.html

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,7 @@
      {{ range .Pages }}
           <div style="border: 1px solid black; margin:10px; padding:10px; ">
                <div style="font-size:20px;">
-                    <a href="{{.URL}}">{{.Title}}</a>
+                    <a href="{{.Permalink}}">{{.Title}}</a>
                </div>
                <div style="color:grey; font-size:16px;">{{ dateFormat "Monday, Jan 2, 2006" .Date }}</div>
                <div style="color:grey; font-size:16px;">{{ if .Params.tags }}<strong>Tags:</strong> {{range .Params.tags}}<a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a> {{end}}{{end}}</div>


### PR DESCRIPTION
Replaced .URL with .Permalink to fix the theme for newer versions of Hugo. With .URL, running hugo server -D returned error: Error: error building site: render: failed to render pages: render of "home" failed: "C:\Users\username\Hugo\myHugoSite\themes\ga-hugo-theme\layouts\_default\list.html:14:31": execute of template failed: template: _default/list.html:14:31: executing "_default/list.html" at <.URL>: can't evaluate field URL in type page.Page