### PR TITLE
fix deprecated method in template which did not allow hugo to compile

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,7 @@
      {{ range .Pages }}
           <div style="border: 1px solid black; margin:10px; padding:10px; ">
                <div style="font-size:20px;">
-                    <a href="{{.URL}}">{{.Title}}</a>
+                    <a href="{{.RelPermalink}}">{{.Title}}</a>
                </div>
                <div style="color:grey; font-size:16px;">{{ dateFormat "Monday, Jan 2, 2006" .Date }}</div>
                <div style="color:grey; font-size:16px;">{{ if .Params.tags }}<strong>Tags:</strong> {{range .Params.tags}}<a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a> {{end}}{{end}}</div>


### PR DESCRIPTION
starting a hugo server with the command `hugo server -D` would throw the following error:

`Error: error building site: render: failed to render pages: render of "home" failed: ".../themes/ga-hugo-theme/layouts/_default/list.html:14:31": execute of template failed: template: _default/list.html:14:31: executing "_default/list.html" at <.URL>: can't evaluate field URL in type page.Page`

This is fixed by changing the `.URL` method into `.RelPermalink`.